### PR TITLE
Set PEP8 checker to skip blank notebook cells

### DIFF
--- a/.github/helpers/pep8_nb_checker.py
+++ b/.github/helpers/pep8_nb_checker.py
@@ -41,6 +41,13 @@ code_file = pathlib.Path(f"{nb_file.stem}_scripted.py")
 warn_file = pathlib.Path(f"{nb_file.stem}_pep8.txt")
 nb_magic_file = pathlib.Path(".github/helpers/nb_flake8_magic.json")
 
+def check_cell_content(source):
+    """Verify that a cell contains any content besides whitespace or newlines"""
+    for line in source:
+        if re.search('^(?!(?:\\n)$)', line):
+            # a "negative lookahead" for any characters in "non-capturing group"
+            return True
+
 # save code cell contents to a script divided into blocks with the separator
 code_cells = []
 with open(nb_file) as nf:
@@ -48,7 +55,11 @@ with open(nb_file) as nf:
 
     with open(code_file, 'w') as cf:
         for i, cl in enumerate(og_nb['cells']):
-            if cl['cell_type'] == 'code':
+            if (cl['cell_type'] == 'code'
+                and cl['source']
+                and check_cell_content(cl['source'])
+            ):
+                # only check code cells containing actual code; skip blanks
                 code_cells.append(i)
                 for o in cl['source']:
                     # comment out lines with IPython magic commands


### PR DESCRIPTION
The notebook in #1 was causing an error because its last cell was blank, which led to PEP8 warning E303 (too many blank lines) when combined with the buffer lines used in `pep8_nb_checker.py`'s process that converts `.ipynb` files to `.py`.

The script now checks a cell contains any characters besides whitespace or newlines (`\n`) before counting it as one to include in the converted file.