### PR TITLE
Allow for cell-specific disabling of PEP8 checker

### DIFF
--- a/.github/helpers/pep8_nb_checker.py
+++ b/.github/helpers/pep8_nb_checker.py
@@ -63,9 +63,26 @@ with open(nb_file) as nf:
             ):
                 # only check code cells containing actual code; skip blanks
                 code_cells.append(i)
+
+                # check zeroth line for comment on errors to be ignored in this
+                # cell. if any, generate appropriate "noqa" comment
+                top_line = cl['source'][0]
+                noqa_check = re.search('^# flake8-ignore', top_line)
+                noqa_comment = ('' if noqa_check is None
+                                else '  # noqa' + top_line[noqa_check.end():])
+
                 for ln in cl['source']:
                     # comment out lines with IPython magic commands
                     line = ln if ln[0] != '%' else '# ' + ln
+
+                    # insert noqa comment if needed (with care for newline char)
+                    if (noqa_comment and not line.startswith('#')
+                            and line != '\n' and line.endswith('\n')):
+                        line = line[:-1] + noqa_comment
+                    elif (noqa_comment and not line.startswith('#')
+                            and line != '\n'):
+                        line += noqa_comment
+
                     cf.write(line)
                 cf.write('\n' * buffer_lines)
                 cf.write(separator)


### PR DESCRIPTION
PR 99 produced a situation where it would be useful to ignore a specific warning in a particular cell, but per this [Stack Overflow response](https://stackoverflow.com/questions/64428794/flake8-disable-linter-only-for-a-block-of-code/64431741#64431741), there is not and will not be a way to ignore a block of code with `flake8`. I wrote one into this repository's PEP8 checking script instead.

To ignore a specific warning in a particular cell, start the cell with a comment like `# flake8-ignore: E402`. To ignore multiple specific warnings, separate their codes with commas. Though it should be extremely rare, one would start a cell with `# flake8-ignore` on its own in order to ignore all PEP8 errors in the cell. All other comments, code, etc. should go below this command.